### PR TITLE
MainActivity.java: more robust resource copying

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MainActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MainActivity.java
@@ -30,6 +30,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -272,18 +273,24 @@ public class MainActivity extends AppCompatActivity  implements Observer {
     }
 
     public void checkResources() {
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
-        if (!preferences.getBoolean("resources_copied", false)) {
-            copyResources(R.raw.hosts, "hosts.txt");
-            copyResources(R.raw.geoipasnum, "GeoIPASNum.dat");
-            copyResources(R.raw.geoip, "GeoIP.dat");
-            copyResources(R.raw.global, "global.txt");
-            PreferenceManager.getDefaultSharedPreferences(this).edit().putBoolean("resources_copied", true).apply();
-        }
+        copyResources(R.raw.hosts, "hosts.txt");
+        copyResources(R.raw.geoipasnum, "GeoIPASNum.dat");
+        copyResources(R.raw.geoip, "GeoIP.dat");
+        copyResources(R.raw.global, "global.txt");
     }
 
     private void copyResources(int id, String filename) {
-        Log.v(TAG, "copyResources...");
+        boolean exists = false;
+        try {
+            openFileInput(filename);
+            exists = true;
+        } catch (FileNotFoundException exc) {
+            /* FALLTHROUGH */
+        }
+        if (exists) {
+            return;
+        }
+        Log.v(TAG, "copyResources: " + filename + " ...");
         try {
             InputStream in = getResources().openRawResource(id);
             FileOutputStream out = openFileOutput(filename, 0);
@@ -293,9 +300,9 @@ public class MainActivity extends AppCompatActivity  implements Observer {
         } catch (java.io.IOException err) {
             // XXX suppress exception
             // XXX not closing in and out
-            Log.e(TAG, "copyResources: error: " + err);
+            Log.e(TAG, "copyResources: error: " + err + " for: " + filename);
         }
-        Log.v(TAG, "copyResources... done");
+        Log.v(TAG, "copyResources: " + filename + " ... done");
     }
 
     public void startInformedConsentActivity() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/NetworkMeasurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/NetworkMeasurement.java
@@ -7,18 +7,18 @@ import org.json.JSONObject;
 import org.openobservatory.ooniprobe.R;
 
 public class NetworkMeasurement {
-    public final String testName;
+    public String testName = "";
     public boolean entry = false;
-    public final long test_id;
+    public long test_id = 0;
     public int progress = 0;
 
     public final String json_file;
     public final String log_file;
-    public Boolean running;
-    public Boolean viewed;
-    public int anomaly;
+    public boolean running = false;
+    public boolean viewed = false;
+    public int anomaly = 0;
 
-    public NetworkMeasurement(String name){
+    public NetworkMeasurement(String name) {
         this.testName = name;
         this.test_id = System.currentTimeMillis();
         this.log_file = "/test-"+ test_id +".log";


### PR DESCRIPTION
Rather than relying on a shared preference, directly check whether
the file is there or not and, in the latter case, copy it.

Observed during #76. Depends on #78.