### PR TITLE
Fixes url for gay.com

### DIFF
--- a/app/src/main/res/raw/global.txt
+++ b/app/src/main/res/raw/global.txt
@@ -524,7 +524,7 @@ http://www.gamenode.com
 http://www.gamespot.com
 http://www.gamingday.com
 http://www.gatesfoundation.org
-https://www.gay.com/
+http://www.gay.com/
 http://www.gayegypt.com
 http://www.gayhealth.com
 http://www.gayscape.com


### PR DESCRIPTION
Addresses #106 
I built and verified that this fix works on a Nexus 5X running CopperheadOS