### PR TITLE
hotfix(VersionUtility): do not include build number

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/utils/VersionUtils.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/utils/VersionUtils.java
@@ -6,6 +6,8 @@ import org.openobservatory.ooniprobe.model.OONITests;
 public class VersionUtils {
 
     public static String get_software_version(){
-        return BuildConfig.VERSION_NAME + "+" + BuildConfig.VERSION_CODE;
+        // FIXME: submitting the VERSION_CODE breaks OONI backend
+        //return BuildConfig.VERSION_NAME + "+" + BuildConfig.VERSION_CODE;
+        return BuildConfig.VERSION_NAME;
     }
 }


### PR DESCRIPTION
This breaks OONI Backend.

See TheTorProject/ooni-backend#111 and TheTorProject/ooni-sysadmin#164.